### PR TITLE
Commit jumping and line matching fixes

### DIFF
--- a/gitbrowse/browser.py
+++ b/gitbrowse/browser.py
@@ -73,6 +73,17 @@ class GitBrowser(ModalScrollingInterface):
             'message': self.file_history.current_commit.message,
         }
 
+    def _update_mapping(self, start, finish):
+        mapping = self.file_history.line_mapping(start, finish)
+        new_highlight_line = mapping.get(self.highlight_line)
+        if new_highlight_line is not None:
+            self.highlight_line = new_highlight_line
+        else:
+            # The highlight_line setter validates the value, so it makes
+            # sense to set it to the same value here to make sure that it's
+            # not out of range for the newly loaded revision of the file.
+            self.highlight_line = self.highlight_line
+
     def _move_commit(self, method_name):
         start = self.file_history.current_commit.sha
 
@@ -83,15 +94,7 @@ class GitBrowser(ModalScrollingInterface):
 
         finish = self.file_history.current_commit.sha
 
-        mapping = self.file_history.line_mapping(start, finish)
-        new_highlight_line = mapping.get(self.highlight_line)
-        if new_highlight_line is not None:
-            self.highlight_line = new_highlight_line
-        else:
-            # The highlight_line setter validates the value, so it makes
-            # sense to set it to the same value here to make sure that it's
-            # not out of range for the newly loaded revision of the file.
-            self.highlight_line = self.highlight_line
+        self._update_mapping(start, finish)
 
     @ModalScrollingInterface.key_bindings(']')
     def next_commit(self, times=1):

--- a/gitbrowse/browser.py
+++ b/gitbrowse/browser.py
@@ -96,6 +96,27 @@ class GitBrowser(ModalScrollingInterface):
 
         self._update_mapping(start, finish)
 
+    def _jump_to_commit(self, sha):
+
+        start = self.file_history.current_commit.sha
+
+        if not self.file_history.jump_to_commit(sha):
+            curses.beep()
+            return
+
+        finish = sha
+
+        if start == finish:
+            curses.beep()
+            return
+
+        self._update_mapping(start, finish)
+
+    @ModalScrollingInterface.key_bindings('j')
+    def info(self, times=1):
+        blame_line = self.content()[self.highlight_line]
+        self._jump_to_commit(blame_line.sha)
+
     @ModalScrollingInterface.key_bindings(']')
     def next_commit(self, times=1):
         for i in range(0,times):

--- a/gitbrowse/git.py
+++ b/gitbrowse/git.py
@@ -182,8 +182,8 @@ class GitFileHistory(object):
         sections = []
 
         # Skip initial headers: They don't interest us.
-        line = ''
-        while not line.startswith('@@'):
+        line = p.readline()
+        while line != '' and not line.startswith('@@'):
             line = p.readline()
 
         while line:

--- a/gitbrowse/git.py
+++ b/gitbrowse/git.py
@@ -113,9 +113,9 @@ class GitFileHistory(object):
 
         lines = []
 
-        p = os.popen('git blame -p %s %s' % (
-            self.path,
+        p = os.popen('git blame -p %s -- %s' % (
             self.current_commit.sha,
+            self.path,
         ))
 
         while True:

--- a/gitbrowse/git.py
+++ b/gitbrowse/git.py
@@ -41,8 +41,8 @@ class GitFileHistory(object):
                 start_commit,
             ))
 
-        if not verify_file(path):
-            raise ValueError('"%s" is not tracked by git' % (path, ))
+        if not verify_file(path, start_commit):
+            raise ValueError('"%s" is not tracked by git at commit %s' % (path, start_commit))
 
         self.path = path
 
@@ -267,11 +267,10 @@ def verify_revision(rev):
     return status == 0
 
 
-def verify_file(path):
+def verify_file(path, commit):
     """
     Verifies that a given file is tracked by Git and returns true or false
     accordingly.
     """
-    p = os.popen('git ls-files -- %s' % path)
-    matching_files = p.readlines()
-    return len(matching_files) > 0
+    exit_code = subprocess.Popen(['git', 'cat-file', '-e', '%s:%s' % (commit, path)]).wait()
+    return exit_code == 0

--- a/gitbrowse/git.py
+++ b/gitbrowse/git.py
@@ -87,6 +87,22 @@ class GitFileHistory(object):
         self._blame = None
         return True
 
+    def jump_to_commit(self, sha):
+        """
+        Moves to the given commit SHA, returning False if it doesn't exist.
+        """
+        found_index = None
+        for i, commit in enumerate(self.commits):
+            if commit.sha == sha:
+                found_index = i
+
+        if found_index is None:
+            return False
+
+        self._index = found_index
+        self._blame = None
+        return True
+
     def blame(self):
         """
         Returns blame information for this file at the current commit as

--- a/gitbrowse/ui.py
+++ b/gitbrowse/ui.py
@@ -81,8 +81,8 @@ class ModalScrollingInterface(object):
 
     @highlight_line.setter
     def highlight_line(self, value):
-        # Ensure highlighted line in sane
-        max_highlight = len(self.file_history.blame()) - 1
+        # Ensure highlighted line is sane
+        max_highlight = max(0, len(self.file_history.blame()) - 1)
         if value < 0:
             value = 0
         elif value > max_highlight:


### PR DESCRIPTION
This PR fixes a couple of issues that made git-browse unusable for me:
- Line matching didn't always work correctly
- Getting stuck on an empty screen when going back too far
- Not being able to jump to the commit that introduced a line of code (there's anoter PR #3 to address that, but I think `j` for "jump" might be a more natural key)
